### PR TITLE
fix(interceptor): auto-generate dev JWT secret when missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ admin/vendor/
 vendor/
 /vendor/
 .DS_Store
+interceptor/.jwt-secret

--- a/interceptor/index.js
+++ b/interceptor/index.js
@@ -20,7 +20,27 @@ const ObjectId = mongodb.ObjectId;
 const PORT = process.env.PORT || 3000;
 const DB_URI = "mongodb://localhost:27017";
 const DB_NAME = "horizon";
-const JWT_SECRET = process.env.JWT_SECRET;
+function resolveJwtSecret() {
+  const envSecret = String(process.env.JWT_SECRET || "").trim();
+  if (envSecret.length >= 32) return envSecret;
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("Missing/weak JWT_SECRET. Set a strong value (minimum 32 chars).");
+  }
+
+  const devSecretFile = path.join(__dirname, ".jwt-secret");
+  if (fs.existsSync(devSecretFile)) {
+    const fileSecret = fs.readFileSync(devSecretFile, "utf8").trim();
+    if (fileSecret.length >= 32) return fileSecret;
+  }
+
+  const generatedSecret = crypto.randomBytes(48).toString("hex");
+  fs.writeFileSync(devSecretFile, generatedSecret, { encoding: "utf8", mode: 0o600 });
+  console.warn("[auth] JWT_SECRET not found. Generated a local development secret at interceptor/.jwt-secret.");
+  return generatedSecret;
+}
+
+const JWT_SECRET = resolveJwtSecret();
 const MAIN_URL = `http://localhost:${PORT}`;
 const WS_ORIGIN_ALLOWLIST = (process.env.WS_ORIGIN_ALLOWLIST || "").split(",").map(v => v.trim()).filter(Boolean);
 const CORS_ORIGIN_ALLOWLIST = (process.env.CORS_ORIGIN_ALLOWLIST || "").split(",").map(v => v.trim()).filter(Boolean);
@@ -59,10 +79,6 @@ function isRateLimited(key, maxAttempts = 10, windowMs = 10 * 60 * 1000) {
   state.count += 1;
   authAttempts.set(key, state);
   return state.count > maxAttempts;
-}
-
-if (!JWT_SECRET || JWT_SECRET.length < 32) {
-  throw new Error("Missing/weak JWT_SECRET. Set a strong value (minimum 32 chars).");
 }
 
 const profilesUploadDir = path.join(__dirname, "uploads", "profiles");


### PR DESCRIPTION
### Motivation
- Local development crashes on startup when `JWT_SECRET` is not set, so improve developer experience by allowing safe defaults outside production. 
- Maintain strict security in production by retaining the existing failure when a strong secret is not provided. 
- Persist a development secret so restarts don't repeatedly regenerate different tokens and break local sessions.

### Description
- Add `resolveJwtSecret()` to `interceptor/index.js` which returns a strong secret from `process.env.JWT_SECRET` when present and valid (>= 32 chars). 
- When `NODE_ENV === "production"` and no valid env secret exists, rethrow the original error to preserve production safety. 
- In non-production, load a persisted secret from `interceptor/.jwt-secret` if present or generate a new one with `crypto.randomBytes(48)` and write it to `interceptor/.jwt-secret` using file mode `0o600`, and log a warning. 
- Add `interceptor/.jwt-secret` to the root `.gitignore` and remove the previous unconditional startup throw that caused the local crash.

### Testing
- Ran `node interceptor/index.js` and confirmed the server starts and prints a warning that a development secret was generated. 
- Verified the running process existed and could be stopped using `pgrep -f 'node interceptor/index.js'` and `pkill -f 'node interceptor/index.js'`. 
- Confirmed repository changes (`.gitignore` and `interceptor/index.js`) produce the expected behavior when starting the interceptor with no `JWT_SECRET` set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83e9fdcb8832b82427e0940cea9e1)