### PR TITLE
Dev JWT secret handling and login/signup UI interaction improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ admin/vendor/
 vendor/
 /vendor/
 .DS_Store
+interceptor/.jwt-secret

--- a/app/src/main/java/com/example/horizon/ui/fragment/login/login.kt
+++ b/app/src/main/java/com/example/horizon/ui/fragment/login/login.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.example.horizon.Interface.FrameLayoutChanger
 import com.example.horizon.MainActivity
@@ -49,9 +50,13 @@ class login : Fragment(){
 
     private fun setupClickListeners() {
         binding.apply {
-            Login.setOnClickListener {
+            val loginAction = {
                 viewModel.login(usernameOr.text.toString(), password.text.toString())
             }
+            loginContainer.setOnClickListener { loginAction() }
+            Login.setOnClickListener { loginAction() }
+            Loginbtn.setOnClickListener { loginAction() }
+
             signUplogin.setOnClickListener { viewModel.onSignUpClicked() }
             forgotPass.setOnClickListener { viewModel.onForgotPasswordClicked() }
         }
@@ -88,11 +93,11 @@ class login : Fragment(){
     }
 
     private fun showError(message: String) {
-        // Show error message to user
+        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
     }
 
     private fun showLoading() {
-        // Show loading indicator
+        Toast.makeText(requireContext(), "Please wait...", Toast.LENGTH_SHORT).show()
     }
 
 }

--- a/app/src/main/java/com/example/horizon/ui/fragment/signup/signup.kt
+++ b/app/src/main/java/com/example/horizon/ui/fragment/signup/signup.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.example.horizon.Interface.FrameLayoutChanger
@@ -46,9 +47,13 @@ class signup: Fragment() {
 
     private fun setupClickListeners() {
         binding.apply {
-            createaccount.setOnClickListener {
-                viewModel.signUp(usernameOr.text.toString() , password.text.toString() , cnfpassword.text.toString())
+            val submitAction = {
+                viewModel.signUp(usernameOr.text.toString(), password.text.toString(), cnfpassword.text.toString())
             }
+            createaccountContainer.setOnClickListener { submitAction() }
+            createaccount.setOnClickListener { submitAction() }
+            Loginbtn.setOnClickListener { submitAction() }
+
             logintxt.setOnClickListener {
                 viewModel.onLoginClicked()
             }
@@ -82,11 +87,11 @@ class signup: Fragment() {
     }
 
     private fun showError(message: String) {
-        // Show error message to user
+        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
     }
 
     private fun showLoading() {
-        // Show loading indicator
+        Toast.makeText(requireContext(), "Please wait...", Toast.LENGTH_SHORT).show()
     }
 
 

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -48,7 +48,7 @@
                 android:drawableStart="@drawable/user"
                 android:paddingStart="16dp"
                 android:drawablePadding="16dp"
-                android:hint="@string/username"
+                android:hint="@string/username_only"
                 android:textColor="@color/black"
                 android:textColorHint="@color/dark_blue"
                 android:textSize="18sp"
@@ -97,12 +97,15 @@
         />
 
     <RelativeLayout
+        android:id="@+id/login_container"
         android:layout_width="317dp"
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
         android:layout_gravity="center_horizontal"
-        android:layout_marginTop="9dp">
+        android:layout_marginTop="9dp"
+        android:clickable="true"
+        android:focusable="true">
 
         <ImageView
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -45,7 +45,7 @@
             android:drawableStart="@drawable/user"
             android:paddingStart="16dp"
             android:drawablePadding="16dp"
-            android:hint="@string/username"
+            android:hint="@string/username_only"
             android:textColor="@color/black"
             android:textColorHint="@color/dark_blue"
             android:textSize="18sp"
@@ -111,12 +111,15 @@
         android:gravity="top"
         />
     <RelativeLayout
+        android:id="@+id/createaccount_container"
         android:layout_width="317dp"
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
         android:layout_gravity="center_horizontal"
-        android:layout_marginTop="30dp">
+        android:layout_marginTop="30dp"
+        android:clickable="true"
+        android:focusable="true">
 
         <ImageView
             android:id="@+id/createaccount"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="login_failed">"Login failed"</string>
     <string name="welcome_bac">Welcome \nBack!\n</string>
     <string name="username">Username or Email</string>
+    <string name="username_only">Username</string>
     <string name="password">Password</string>
     <string name="forgot_pass">Forgot Password?</string>
     <string name="login">Login</string>

--- a/interceptor/index.js
+++ b/interceptor/index.js
@@ -20,7 +20,27 @@ const ObjectId = mongodb.ObjectId;
 const PORT = process.env.PORT || 3000;
 const DB_URI = "mongodb://localhost:27017";
 const DB_NAME = "horizon";
-const JWT_SECRET = process.env.JWT_SECRET;
+function resolveJwtSecret() {
+  const envSecret = String(process.env.JWT_SECRET || "").trim();
+  if (envSecret.length >= 32) return envSecret;
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("Missing/weak JWT_SECRET. Set a strong value (minimum 32 chars).");
+  }
+
+  const devSecretFile = path.join(__dirname, ".jwt-secret");
+  if (fs.existsSync(devSecretFile)) {
+    const fileSecret = fs.readFileSync(devSecretFile, "utf8").trim();
+    if (fileSecret.length >= 32) return fileSecret;
+  }
+
+  const generatedSecret = crypto.randomBytes(48).toString("hex");
+  fs.writeFileSync(devSecretFile, generatedSecret, { encoding: "utf8", mode: 0o600 });
+  console.warn("[auth] JWT_SECRET not found. Generated a local development secret at interceptor/.jwt-secret.");
+  return generatedSecret;
+}
+
+const JWT_SECRET = resolveJwtSecret();
 const MAIN_URL = `http://localhost:${PORT}`;
 const WS_ORIGIN_ALLOWLIST = (process.env.WS_ORIGIN_ALLOWLIST || "").split(",").map(v => v.trim()).filter(Boolean);
 const CORS_ORIGIN_ALLOWLIST = (process.env.CORS_ORIGIN_ALLOWLIST || "").split(",").map(v => v.trim()).filter(Boolean);
@@ -59,10 +79,6 @@ function isRateLimited(key, maxAttempts = 10, windowMs = 10 * 60 * 1000) {
   state.count += 1;
   authAttempts.set(key, state);
   return state.count > maxAttempts;
-}
-
-if (!JWT_SECRET || JWT_SECRET.length < 32) {
-  throw new Error("Missing/weak JWT_SECRET. Set a strong value (minimum 32 chars).");
 }
 
 const profilesUploadDir = path.join(__dirname, "uploads", "profiles");


### PR DESCRIPTION
### Motivation
- Ensure the interceptor server can run in development without a pre-set `JWT_SECRET` while enforcing a strong secret in production.
- Improve user experience on login and signup screens by making the full button area clickable and providing immediate feedback for errors and loading.
- Keep local generated secrets out of version control.

### Description
- Add a `resolveJwtSecret()` helper in `interceptor/index.js` that loads `JWT_SECRET` from the environment, reads an existing `interceptor/.jwt-secret` file, or generates and persists a secure random secret for development, and enforce a minimum length in production.
- Remove the previous unconditional JWT secret check and replace it with the new resolution flow; newly generated secrets are written with restrictive file mode `0o600` and a warning is logged for developers.
- Add `interceptor/.jwt-secret` to `.gitignore` to avoid committing generated development secrets.
- Update Android login and signup fragments to centralize click actions into lambdas and attach them to the image, text label, and surrounding container (`login_container` and `createaccount_container`) so the whole control is clickable; add `clickable` and `focusable` attributes to those containers in layout XML.
- Replace placeholder comments for error/loading states with visible `Toast` messages in `login.kt` and `signup.kt` and add a new string resource `username_only` used for the username hint.

### Testing
- Ran a local smoke start of the interceptor server with `node interceptor/index.js` to verify secret resolution and file creation, which started successfully and logged the development secret creation warning.
- Performed an Android debug build with `./gradlew assembleDebug` to validate layout and resource changes, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83e9fdcb8832b82427e0940cea9e1)